### PR TITLE
updated timer creation to match the documented and correct way specif…

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,29 +58,29 @@ SUBSYSTEM=="input", ATTRS{name}=="*Wireless Controller Touchpad", RUN+="/bin/rm 
 
 ### Docker
 
-The `Dockerfile` contained in the root of this respository has an example ROS2 Foxy container setup you might use. 
+The `Dockerfile` contained in the root of this repository has an example ROS2 Foxy container setup you might use. 
 
 ```
 docker build -t ds4_driver/foxy .
+```
 
-docker run -it  \
-  --device /dev/input \
-  --device /dev/snd \
-  --device /dev/hidraw0 \
-  --device /dev/hidraw1 \
-  --device /dev/hidraw2 \
-  --device /dev/hidraw3 \
-  --device /dev/hidraw4 \
-  --device /dev/hidraw5 \
-  --network=host \
-  ds4_driver/foxy
+After building the image you can automatically run the container by starting a new terminal from the `ds4_driver` project 
+root and running the `run_bringup.bash` script which takes the path to the local `ds4_driver` project root as an optional
+first argument, like this:
 
+```
+bash run_bringup.bash <path_to_local_ds4_driver_project_root>
+```
+
+After running the above script the console will go into the running container and you can run from there or from a new 
+terminal executed into the container:
+
+```
 # Now go into the container (`docker exec -it $CONTAINER_NAME bash`),
 # where $CONTAINER_NAME can be the name of the running container
 source install/setup.bash
 
-ros2 run ds4_driver 
-
+ros2 run ds4_driver ds4_driver_node.py
 ```
 
 ## Demonstration

--- a/ds4_driver/controller_ros.py
+++ b/ds4_driver/controller_ros.py
@@ -1,6 +1,5 @@
 from ds4_driver.controller import Controller
 
-import rclpy
 from sensor_msgs.msg import BatteryState
 from sensor_msgs.msg import Joy
 from sensor_msgs.msg import JoyFeedback
@@ -34,6 +33,8 @@ class ControllerRos(Controller):
         self._autorepeat_rate = self.node.get_parameter('autorepeat_rate').value
         self._prev_joy = None
 
+        self.stop_rumble_timer = None
+
         # Use ROS-standard messages (like sensor_msgs/Joy)
         if self.use_standard_msgs:
             self.pub_report = self.node.create_publisher(Report, 'raw_report', 0)
@@ -44,7 +45,7 @@ class ControllerRos(Controller):
 
             if self._autorepeat_rate != 0:
                 period = 1.0 / self._autorepeat_rate
-                rclpy.Timer(rclpy.Duration.from_sec(period), self.cb_joy_pub_timer)
+                self.node.create_timer(period, self.cb_joy_pub_timer)
         else:
             self.pub_status = self.node.create_publisher(Status, 'status', 1)
             self.sub_feedback = self.node.create_subscription(Feedback,'set_feedback', self.cb_feedback, 0)
@@ -119,13 +120,14 @@ class ControllerRos(Controller):
 
         # Timer to stop rumble
         if msg.set_rumble and msg.rumble_duration != 0:
-            rclpy.Timer(rclpy.Duration(msg.rumble_duration),
-                        self.cb_stop_rumble,
-                        oneshot=True)
+            self.stop_rumble_timer = self.node.create_timer(msg.rumble_duration, self.cb_stop_rumble)
 
-    def cb_stop_rumble(self, event):
+    def cb_stop_rumble(self):
         try:
             self.control(rumble_small=0, rumble_big=0)
+
+            if self.stop_rumble_timer is not None:
+                self.stop_rumble_timer.destroy()
         except AttributeError:
             # The program exited and self.device was set to None
             pass
@@ -162,7 +164,7 @@ class ControllerRos(Controller):
 
         self.cb_feedback(feedback)
 
-    def cb_joy_pub_timer(self, _):
+    def cb_joy_pub_timer(self):
         if self._prev_joy is not None:
             self.pub_joy.publish(self._prev_joy)
 

--- a/run_bringup.bash
+++ b/run_bringup.bash
@@ -1,0 +1,19 @@
+#!/bin/bash
+DS4_DRIVER_LOCAL_PATH="$1"
+
+if [ "$DS4_DRIVER_LOCAL_PATH" != "" ]; then
+   docker rm ds4_drv_container
+
+    # before running this put the export the DS4_DRIVER_LOCAL_PATH variable in your current terminal or
+    # place it in ~/.bashrc and source it
+    docker run -it \
+      -v "/dev:/dev" \
+      -v "$DS4_DRIVER_LOCAL_PATH:/opt/underlay_ws/src" \
+      --privileged \
+      --name="ds4_drv_container" \
+      --network=host \
+      ds4_driver/foxy bash
+else
+    echo "Give the ds4_driver local source path as an argument to this script!"
+fi
+


### PR DESCRIPTION
…ied in latest rclpy version (#18)

* updated Timers usage to new rclpy version

* trying something

* replaced creation of Timers with rclpy.Timer() with correct self.node.create_timer(). Added new bringup script for the Docker container

* cleaned unused import in controller_ros.py

* updated README.md

* updated the run_bringup.bash and README.md according to comments from the original project author

Co-authored-by: George Porusniuc <george.porusniuc@karelics.fi>